### PR TITLE
Use Bluetooth MAC address instead of UUID on MacOS

### DIFF
--- a/findmy/scanner/scanner.py
+++ b/findmy/scanner/scanner.py
@@ -131,7 +131,7 @@ class OfflineFindingScanner:
         You most likely do not want to use this yourself;
         check out `OfflineFindingScanner.create` instead.
         """
-        self._scanner: BleakScanner = BleakScanner(self._scan_callback)
+        self._scanner: BleakScanner = BleakScanner(self._scan_callback, cb=dict(use_bdaddr=True))
 
         self._loop = loop
         self._device_fut: asyncio.Future[tuple[BLEDevice, AdvertisementData]] = loop.create_future()


### PR DESCRIPTION
As per [BleakScanner's documentation](https://bleak.readthedocs.io/en/latest/backends/macos.html#bleak.backends.corebluetooth.scanner.CBScannerArgs), MacOS will by default return an UUID of the device rather than a MAC address. This change enables proper use on MacOS.