### PR TITLE
reports: convert timestamps to local timezone

### DIFF
--- a/examples/_login.py
+++ b/examples/_login.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+from findmy.reports import (
+    AppleAccount,
+    AsyncAppleAccount,
+    BaseAnisetteProvider,
+    LoginState,
+    SmsSecondFactorMethod,
+    TrustedDeviceSecondFactorMethod,
+)
+
+ACCOUNT_STORE = "account.json"
+
+
+def _login_sync(account: AppleAccount) -> None:
+    email = input("email?  > ")
+    password = input("passwd? > ")
+
+    state = account.login(email, password)
+
+    if state == LoginState.REQUIRE_2FA:  # Account requires 2FA
+        # This only supports SMS methods for now
+        methods = account.get_2fa_methods()
+
+        # Print the (masked) phone numbers
+        for i, method in enumerate(methods):
+            if isinstance(method, TrustedDeviceSecondFactorMethod):
+                print(f"{i} - Trusted Device")
+            elif isinstance(method, SmsSecondFactorMethod):
+                print(f"{i} - SMS ({method.phone_number})")
+
+        ind = int(input("Method? > "))
+
+        method = methods[ind]
+        method.request()
+        code = input("Code? > ")
+
+        # This automatically finishes the post-2FA login flow
+        method.submit(code)
+
+
+async def _login_async(account: AsyncAppleAccount) -> None:
+    email = input("email?  > ")
+    password = input("passwd? > ")
+
+    state = await account.login(email, password)
+
+    if state == LoginState.REQUIRE_2FA:  # Account requires 2FA
+        # This only supports SMS methods for now
+        methods = await account.get_2fa_methods()
+
+        # Print the (masked) phone numbers
+        for i, method in enumerate(methods):
+            if isinstance(method, TrustedDeviceSecondFactorMethod):
+                print(f"{i} - Trusted Device")
+            elif isinstance(method, SmsSecondFactorMethod):
+                print(f"{i} - SMS ({method.phone_number})")
+
+        ind = int(input("Method? > "))
+
+        method = methods[ind]
+        await method.request()
+        code = input("Code? > ")
+
+        # This automatically finishes the post-2FA login flow
+        await method.submit(code)
+
+
+def get_account_sync(anisette: BaseAnisetteProvider) -> AppleAccount:
+    """Tries to restore a saved Apple account, or prompts the user for login otherwise. (sync)"""
+    acc = AppleAccount(anisette)
+
+    # Save / restore account logic
+    acc_store = Path("account.json")
+    try:
+        with acc_store.open() as f:
+            acc.restore(json.load(f))
+    except FileNotFoundError:
+        _login_sync(acc)
+        with acc_store.open("w+") as f:
+            json.dump(acc.export(), f)
+
+    return acc
+
+
+async def get_account_async(anisette: BaseAnisetteProvider) -> AsyncAppleAccount:
+    """Tries to restore a saved Apple account, or prompts the user for login otherwise. (async)"""
+    acc = AsyncAppleAccount(anisette)
+
+    # Save / restore account logic
+    acc_store = Path("account.json")
+    try:
+        with acc_store.open() as f:
+            acc.restore(json.load(f))
+    except FileNotFoundError:
+        await _login_async(acc)
+        with acc_store.open("w+") as f:
+            json.dump(acc.export(), f)
+
+    return acc

--- a/examples/fetch_reports.py
+++ b/examples/fetch_reports.py
@@ -1,25 +1,15 @@
-import json
 import logging
-from pathlib import Path
+
+from _login import get_account_sync
 
 from findmy import KeyPair
-from findmy.reports import (
-    AppleAccount,
-    LoginState,
-    RemoteAnisetteProvider,
-    SmsSecondFactorMethod,
-    TrustedDeviceSecondFactorMethod,
-)
+from findmy.reports import RemoteAnisetteProvider
 
 # URL to (public or local) anisette server
 ANISETTE_SERVER = "http://localhost:6969"
 
-# Apple account details
-ACCOUNT_EMAIL = "test@test.com"
-ACCOUNT_PASS = ""
-
 # Private base64-encoded key to look up
-KEY_PRIV = ""
+KEY_PRIV = "Vq/RNibhblTitwb7hjPkZZj6gyJcAJSVMQ6Shg=="
 
 # Optional, to verify that advertisement key derivation works for your key
 KEY_ADV = ""
@@ -27,43 +17,9 @@ KEY_ADV = ""
 logging.basicConfig(level=logging.DEBUG)
 
 
-def login(account: AppleAccount) -> None:
-    state = account.login(ACCOUNT_EMAIL, ACCOUNT_PASS)
-
-    if state == LoginState.REQUIRE_2FA:  # Account requires 2FA
-        # This only supports SMS methods for now
-        methods = account.get_2fa_methods()
-
-        # Print the (masked) phone numbers
-        for i, method in enumerate(methods):
-            if isinstance(method, TrustedDeviceSecondFactorMethod):
-                print(f"{i} - Trusted Device")
-            elif isinstance(method, SmsSecondFactorMethod):
-                print(f"{i} - SMS ({method.phone_number})")
-
-        ind = int(input("Method? > "))
-
-        method = methods[ind]
-        method.request()
-        code = input("Code? > ")
-
-        # This automatically finishes the post-2FA login flow
-        method.submit(code)
-
-
 def fetch_reports(lookup_key: KeyPair) -> None:
     anisette = RemoteAnisetteProvider(ANISETTE_SERVER)
-    acc = AppleAccount(anisette)
-
-    # Save / restore account logic
-    acc_store = Path("account.json")
-    try:
-        with acc_store.open() as f:
-            acc.restore(json.load(f))
-    except FileNotFoundError:
-        login(acc)
-        with acc_store.open("w+") as f:
-            json.dump(acc.export(), f)
+    acc = get_account_sync(anisette)
 
     print(f"Logged in as: {acc.account_name} ({acc.first_name} {acc.last_name})")
 

--- a/findmy/reports/__init__.py
+++ b/findmy/reports/__init__.py
@@ -1,6 +1,6 @@
 """Code related to fetching location reports."""
 from .account import AppleAccount, AsyncAppleAccount
-from .anisette import RemoteAnisetteProvider
+from .anisette import BaseAnisetteProvider, RemoteAnisetteProvider
 from .state import LoginState
 from .twofactor import SmsSecondFactorMethod, TrustedDeviceSecondFactorMethod
 
@@ -8,6 +8,7 @@ __all__ = (
     "AppleAccount",
     "AsyncAppleAccount",
     "LoginState",
+    "BaseAnisetteProvider",
     "RemoteAnisetteProvider",
     "SmsSecondFactorMethod",
     "TrustedDeviceSecondFactorMethod",

--- a/findmy/reports/reports.py
+++ b/findmy/reports/reports.py
@@ -121,7 +121,7 @@ class LocationReport:
         Requires a `KeyPair` to decrypt the report's payload.
         """
         timestamp_int = int.from_bytes(payload[0:4], "big") + (60 * 60 * 24 * 11323)
-        timestamp = datetime.fromtimestamp(timestamp_int, tz=timezone.utc)
+        timestamp = datetime.fromtimestamp(timestamp_int, tz=timezone.utc).astimezone()
 
         data = _decrypt_payload(payload, key)
         latitude = struct.unpack(">i", data[0:4])[0] / 10000000
@@ -232,7 +232,7 @@ class LocationReportsFetcher:
             date_published = datetime.fromtimestamp(
                 report.get("datePublished", 0) / 1000,
                 tz=timezone.utc,
-            )
+            ).astimezone()
             description = report.get("description", "")
             payload = base64.b64decode(report["payload"])
 


### PR DESCRIPTION
- `LocationReport` timestamps are now always in local timezone;
- `real_airtag.py` example updated to fetch location reports for an AirTag;
- `LocationReportsFetcher` updated to support key chunking so it fetches at most 256 keys at once.