### PR TITLE
reports: easier accessory key fetching

### DIFF
--- a/examples/fetch_reports.py
+++ b/examples/fetch_reports.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from _login import get_account_sync
 
@@ -8,30 +9,30 @@ from findmy.reports import RemoteAnisetteProvider
 # URL to (public or local) anisette server
 ANISETTE_SERVER = "http://localhost:6969"
 
-# Private base64-encoded key to look up
-KEY_PRIV = ""
-
-# Optional, to verify that advertisement key derivation works for your key
-KEY_ADV = ""
-
 logging.basicConfig(level=logging.DEBUG)
 
 
-def fetch_reports(lookup_key: KeyPair) -> None:
-    anisette = RemoteAnisetteProvider(ANISETTE_SERVER)
-    acc = get_account_sync(anisette)
+def fetch_reports(priv_key: str) -> int:
+    key = KeyPair.from_b64(priv_key)
+    acc = get_account_sync(
+        RemoteAnisetteProvider(ANISETTE_SERVER),
+    )
 
     print(f"Logged in as: {acc.account_name} ({acc.first_name} {acc.last_name})")
 
     # It's that simple!
-    reports = acc.fetch_last_reports(lookup_key)
+    reports = acc.fetch_last_reports(key)
     for report in sorted(reports):
         print(report)
 
+    return 1
+
 
 if __name__ == "__main__":
-    key = KeyPair.from_b64(KEY_PRIV)
-    if KEY_ADV:  # verify that your adv key is correct :D
-        assert key.adv_key_b64 == KEY_ADV
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <private key>", file=sys.stderr)
+        print(file=sys.stderr)
+        print("The private key should be base64-encoded.", file=sys.stderr)
+        sys.exit(1)
 
-    fetch_reports(key)
+    sys.exit(fetch_reports(sys.argv[1]))

--- a/examples/fetch_reports.py
+++ b/examples/fetch_reports.py
@@ -24,7 +24,7 @@ def fetch_reports(lookup_key: KeyPair) -> None:
     print(f"Logged in as: {acc.account_name} ({acc.first_name} {acc.last_name})")
 
     # It's that simple!
-    reports = acc.fetch_last_reports([lookup_key])[lookup_key]
+    reports = acc.fetch_last_reports(lookup_key)
     for report in sorted(reports):
         print(report)
 

--- a/examples/fetch_reports.py
+++ b/examples/fetch_reports.py
@@ -9,7 +9,7 @@ from findmy.reports import RemoteAnisetteProvider
 # URL to (public or local) anisette server
 ANISETTE_SERVER = "http://localhost:6969"
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 def fetch_reports(priv_key: str) -> int:

--- a/examples/fetch_reports_async.py
+++ b/examples/fetch_reports_async.py
@@ -10,7 +10,7 @@ from findmy.reports import RemoteAnisetteProvider
 # URL to (public or local) anisette server
 ANISETTE_SERVER = "http://localhost:6969"
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 async def fetch_reports(priv_key: str) -> int:

--- a/examples/fetch_reports_async.py
+++ b/examples/fetch_reports_async.py
@@ -27,8 +27,9 @@ async def fetch_reports(lookup_key: KeyPair) -> None:
         print(f"Logged in as: {acc.account_name} ({acc.first_name} {acc.last_name})")
 
         # It's that simple!
-        reports = await acc.fetch_last_reports([lookup_key])
-        print(reports)
+        reports = await acc.fetch_last_reports(lookup_key)
+        for report in sorted(reports):
+            print(report)
 
     finally:
         await acc.close()

--- a/examples/real_airtag.py
+++ b/examples/real_airtag.py
@@ -3,6 +3,7 @@ Example showing how to fetch locations of an AirTag, or any other FindMy accesso
 """
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from _login import get_account_sync
@@ -13,13 +14,10 @@ from findmy.reports import RemoteAnisetteProvider
 # URL to (public or local) anisette server
 ANISETTE_SERVER = "http://localhost:6969"
 
-# Path to a .plist dumped from the Find My app.
-PLIST_PATH = Path("airtag.plist")
 
-
-def main() -> None:
+def main(plist_path: str) -> int:
     # Step 0: create an accessory key generator
-    with PLIST_PATH.open("rb") as f:
+    with Path(plist_path).open("rb") as f:
         airtag = FindMyAccessory.from_plist(f)
 
     # Step 1: log into an Apple account
@@ -37,6 +35,14 @@ def main() -> None:
     for report in reports:
         print(f" - {report}")
 
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <path to accessory plist>", file=sys.stderr)
+        print(file=sys.stderr)
+        print("The plist file should be dumped from MacOS's FindMy app.", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(main(sys.argv[1]))

--- a/examples/real_airtag.py
+++ b/examples/real_airtag.py
@@ -3,6 +3,7 @@ Example showing how to fetch locations of an AirTag, or any other FindMy accesso
 """
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -13,6 +14,8 @@ from findmy.reports import RemoteAnisetteProvider
 
 # URL to (public or local) anisette server
 ANISETTE_SERVER = "http://localhost:6969"
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main(plist_path: str) -> int:

--- a/examples/real_airtag.py
+++ b/examples/real_airtag.py
@@ -50,30 +50,18 @@ def main() -> None:
     # Step 0: create an accessory key generator
     airtag = FindMyAccessory(MASTER_KEY, SKN, SKS, PAIRED_AT)
 
-    # Step 1: Generate the accessory's private keys,
-    # starting from 7 days ago until now (12 hour margin)
-    fetch_to = datetime.now(tz=timezone.utc).astimezone() + timedelta(hours=12)
-    fetch_from = fetch_to - timedelta(days=8)
-
-    print(f"Generating keys from {fetch_from} to {fetch_to} ...")
-    lookup_keys = _gen_keys(airtag, fetch_from, fetch_to)
-
-    print(f"Generated {len(lookup_keys)} keys")
-
-    # Step 2: log into an Apple account
+    # Step 1: log into an Apple account
     print("Logging into account")
     anisette = RemoteAnisetteProvider(ANISETTE_SERVER)
     acc = get_account_sync(anisette)
 
-    # step 3: fetch reports!
+    # step 2: fetch reports!
     print("Fetching reports")
-    reports = acc.fetch_reports(list(lookup_keys), fetch_from, fetch_to)
+    reports = acc.fetch_last_reports(airtag)
 
-    # step 4: print 'em
-    # reports are in {key: [report]} format, but we only really care about the reports
+    # step 3: print 'em
     print()
     print("Location reports:")
-    reports = sorted([r for rs in reports.values() for r in rs])
     for report in reports:
         print(f" - {report}")
 

--- a/examples/real_airtag.py
+++ b/examples/real_airtag.py
@@ -3,13 +3,11 @@ Example showing how to fetch locations of an AirTag, or any other FindMy accesso
 """
 from __future__ import annotations
 
-import plistlib
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from _login import get_account_sync
 
-from findmy import FindMyAccessory, KeyPair
+from findmy import FindMyAccessory
 from findmy.reports import RemoteAnisetteProvider
 
 # URL to (public or local) anisette server
@@ -18,37 +16,11 @@ ANISETTE_SERVER = "http://localhost:6969"
 # Path to a .plist dumped from the Find My app.
 PLIST_PATH = Path("airtag.plist")
 
-# == The variables below are auto-filled from the plist!! ==
-
-with PLIST_PATH.open("rb") as f:
-    device_data = plistlib.load(f)
-
-# PRIVATE master key. 28 (?) bytes.
-MASTER_KEY = device_data["privateKey"]["key"]["data"][-28:]
-
-# "Primary" shared secret. 32 bytes.
-SKN = device_data["sharedSecret"]["key"]["data"]
-
-# "Secondary" shared secret. 32 bytes.
-SKS = device_data["secondarySharedSecret"]["key"]["data"]
-
-# "Paired at" timestamp (UTC)
-PAIRED_AT = device_data["pairingDate"].replace(tzinfo=timezone.utc)
-
-
-def _gen_keys(airtag: FindMyAccessory, _from: datetime, to: datetime) -> set[KeyPair]:
-    keys = set()
-    while _from < to:
-        keys.update(airtag.keys_at(_from))
-
-        _from += timedelta(minutes=15)
-
-    return keys
-
 
 def main() -> None:
     # Step 0: create an accessory key generator
-    airtag = FindMyAccessory(MASTER_KEY, SKN, SKS, PAIRED_AT)
+    with PLIST_PATH.open("rb") as f:
+        airtag = FindMyAccessory.from_plist(f)
 
     # Step 1: log into an Apple account
     print("Logging into account")

--- a/findmy/accessory.py
+++ b/findmy/accessory.py
@@ -99,6 +99,11 @@ class FindMyAccessory(RollingKeyPairSource):
     @override
     def keys_at(self, ind: int | datetime) -> set[KeyPair]:
         """Get the potential primary and secondary keys active at a certain time or index."""
+        if isinstance(ind, datetime) and ind < self._paired_at:
+            return set()
+        if isinstance(ind, int) and ind < 0:
+            return set()
+
         secondary_offset = 0
 
         if isinstance(ind, datetime):

--- a/findmy/reports/reports.py
+++ b/findmy/reports/reports.py
@@ -270,6 +270,19 @@ class LocationReportsFetcher:
             description = report.get("description", "")
             payload = base64.b64decode(report["payload"])
 
-            reports.append(LocationReport.from_payload(key, date_published, description, payload))
+            try:
+                loc_report = LocationReport.from_payload(key, date_published, description, payload)
+            except ValueError as e:
+                logging.warning(
+                    "Location report was not decodable. Some payloads have unknown"
+                    " variations leading to this error. Please report this full message"
+                    " at https://github.com/malmeloo/FindMy.py/issues/27. "
+                    "Payload: %s, Original error: %s",
+                    payload.hex(),
+                    e,
+                )
+                continue
+
+            reports.append(loc_report)
 
         return reports


### PR DESCRIPTION
This PR introduces some quality of life changes to make it easier to work with FindMy accessories:
- Key generation between time ranges is now directly supported using `FindMyAccessory.keys_between`;
- Accessory objects can now be used directly to retrieve reports;
- Accessories can be serialized from compatible .plist files;
- A few other minor bugfixes and QOL changes.

Still needs more testing.

This is one of the last changes before I consider AirTag support to be final, at which point #4 can probably be closed.