### PR TITLE
Avoid generating keys earlier than device pairing time

### DIFF
--- a/findmy/accessory.py
+++ b/findmy/accessory.py
@@ -53,6 +53,8 @@ class FindMyAccessory:
 
         if isinstance(ind, datetime):
             # number of 15-minute slots since pairing time
+            if ind < self._paired_at:
+                ind = self._paired_at
             ind = (
                 int(
                     (ind - self._paired_at).total_seconds() / (15 * 60),


### PR DESCRIPTION
I have a newly paired device (less than 5 days), the fetch_reports example throws an exception because it tries to generate keys before the pairing time.

This change fix the problem by limiting the time no earlier than pairing time.