### PR TITLE
reports: Support fetching encrypted reports

### DIFF
--- a/findmy/keys.py
+++ b/findmy/keys.py
@@ -22,7 +22,37 @@ class KeyType(Enum):
     SECONDARY = 2
 
 
-class HasPublicKey(ABC):
+class HasHashedPublicKey(ABC):
+    """
+    ABC for anything that has a public, hashed FindMy-key.
+
+    Also called a "hashed advertisement" key or "lookup" key.
+    """
+
+    @property
+    @abstractmethod
+    def hashed_adv_key_bytes(self) -> bytes:
+        """Return the hashed advertised (public) key as bytes."""
+        raise NotImplementedError
+
+    @property
+    def hashed_adv_key_b64(self) -> str:
+        """Return the hashed advertised (public) key as a base64-encoded string."""
+        return base64.b64encode(self.hashed_adv_key_bytes).decode("ascii")
+
+    @override
+    def __hash__(self) -> int:
+        return crypto.bytes_to_int(self.hashed_adv_key_bytes)
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, HasHashedPublicKey):
+            return NotImplemented
+
+        return self.hashed_adv_key_bytes == other.hashed_adv_key_bytes
+
+
+class HasPublicKey(HasHashedPublicKey, ABC):
     """
     ABC for anything that has a public FindMy-key.
 
@@ -41,25 +71,10 @@ class HasPublicKey(ABC):
         return base64.b64encode(self.adv_key_bytes).decode("ascii")
 
     @property
+    @override
     def hashed_adv_key_bytes(self) -> bytes:
-        """Return the hashed advertised (public) key as bytes."""
+        """See `HasHashedPublicKey.hashed_adv_key_bytes`."""
         return hashlib.sha256(self.adv_key_bytes).digest()
-
-    @property
-    def hashed_adv_key_b64(self) -> str:
-        """Return the hashed advertised (public) key as a base64-encoded string."""
-        return base64.b64encode(self.hashed_adv_key_bytes).decode("ascii")
-
-    @override
-    def __hash__(self) -> int:
-        return crypto.bytes_to_int(self.adv_key_bytes)
-
-    @override
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, HasPublicKey):
-            return NotImplemented
-
-        return self.adv_key_bytes == other.adv_key_bytes
 
 
 class KeyPair(HasPublicKey):

--- a/findmy/reports/account.py
+++ b/findmy/reports/account.py
@@ -1,4 +1,5 @@
 """Module containing most of the code necessary to interact with an Apple account."""
+
 from __future__ import annotations
 
 import asyncio
@@ -51,7 +52,7 @@ from .twofactor import (
 
 if TYPE_CHECKING:
     from findmy.accessory import RollingKeyPairSource
-    from findmy.keys import KeyPair
+    from findmy.keys import HasHashedPublicKey
     from findmy.util.types import MaybeCoro
 
     from .anisette import BaseAnisetteProvider
@@ -226,7 +227,7 @@ class BaseAppleAccount(Closable, ABC):
     @abstractmethod
     def fetch_reports(
         self,
-        keys: KeyPair,
+        keys: HasHashedPublicKey,
         date_from: datetime,
         date_to: datetime | None,
     ) -> MaybeCoro[list[LocationReport]]:
@@ -236,10 +237,10 @@ class BaseAppleAccount(Closable, ABC):
     @abstractmethod
     def fetch_reports(
         self,
-        keys: Sequence[KeyPair],
+        keys: Sequence[HasHashedPublicKey],
         date_from: datetime,
         date_to: datetime | None,
-    ) -> MaybeCoro[dict[KeyPair, list[LocationReport]]]:
+    ) -> MaybeCoro[dict[HasHashedPublicKey, list[LocationReport]]]:
         ...
 
     @overload
@@ -255,14 +256,14 @@ class BaseAppleAccount(Closable, ABC):
     @abstractmethod
     def fetch_reports(
         self,
-        keys: KeyPair | Sequence[KeyPair] | RollingKeyPairSource,
+        keys: HasHashedPublicKey | Sequence[HasHashedPublicKey] | RollingKeyPairSource,
         date_from: datetime,
         date_to: datetime | None,
-    ) -> MaybeCoro[list[LocationReport] | dict[KeyPair, list[LocationReport]]]:
+    ) -> MaybeCoro[list[LocationReport] | dict[HasHashedPublicKey, list[LocationReport]]]:
         """
-        Fetch location reports for a sequence of `KeyPair`s between `date_from` and `date_end`.
+        Fetch location reports for `HasHashedPublicKey`s between `date_from` and `date_end`.
 
-        Returns a dictionary mapping `KeyPair`s to a list of their location reports.
+        Returns a dictionary mapping `HasHashedPublicKey`s to a list of their location reports.
         """
         raise NotImplementedError
 
@@ -270,7 +271,7 @@ class BaseAppleAccount(Closable, ABC):
     @abstractmethod
     def fetch_last_reports(
         self,
-        keys: KeyPair,
+        keys: HasHashedPublicKey,
         hours: int = 7 * 24,
     ) -> MaybeCoro[list[LocationReport]]:
         ...
@@ -279,9 +280,9 @@ class BaseAppleAccount(Closable, ABC):
     @abstractmethod
     def fetch_last_reports(
         self,
-        keys: Sequence[KeyPair],
+        keys: Sequence[HasHashedPublicKey],
         hours: int = 7 * 24,
-    ) -> MaybeCoro[dict[KeyPair, list[LocationReport]]]:
+    ) -> MaybeCoro[dict[HasHashedPublicKey, list[LocationReport]]]:
         ...
 
     @overload
@@ -296,11 +297,11 @@ class BaseAppleAccount(Closable, ABC):
     @abstractmethod
     def fetch_last_reports(
         self,
-        keys: KeyPair | Sequence[KeyPair] | RollingKeyPairSource,
+        keys: HasHashedPublicKey | Sequence[HasHashedPublicKey] | RollingKeyPairSource,
         hours: int = 7 * 24,
-    ) -> MaybeCoro[list[LocationReport] | dict[KeyPair, list[LocationReport]]]:
+    ) -> MaybeCoro[list[LocationReport] | dict[HasHashedPublicKey, list[LocationReport]]]:
         """
-        Fetch location reports for a sequence of `KeyPair`s for the last `hours` hours.
+        Fetch location reports for a sequence of `HasHashedPublicKey`s for the last `hours` hours.
 
         Utility method as an alternative to using `BaseAppleAccount.fetch_reports` directly.
         """
@@ -627,7 +628,7 @@ class AsyncAppleAccount(BaseAppleAccount):
     @overload
     async def fetch_reports(
         self,
-        keys: KeyPair,
+        keys: HasHashedPublicKey,
         date_from: datetime,
         date_to: datetime | None,
     ) -> list[LocationReport]:
@@ -636,10 +637,10 @@ class AsyncAppleAccount(BaseAppleAccount):
     @overload
     async def fetch_reports(
         self,
-        keys: Sequence[KeyPair],
+        keys: Sequence[HasHashedPublicKey],
         date_from: datetime,
         date_to: datetime | None,
-    ) -> dict[KeyPair, list[LocationReport]]:
+    ) -> dict[HasHashedPublicKey, list[LocationReport]]:
         ...
 
     @overload
@@ -655,10 +656,10 @@ class AsyncAppleAccount(BaseAppleAccount):
     @override
     async def fetch_reports(
         self,
-        keys: KeyPair | Sequence[KeyPair] | RollingKeyPairSource,
+        keys: HasHashedPublicKey | Sequence[HasHashedPublicKey] | RollingKeyPairSource,
         date_from: datetime,
         date_to: datetime | None,
-    ) -> list[LocationReport] | dict[KeyPair, list[LocationReport]]:
+    ) -> list[LocationReport] | dict[HasHashedPublicKey, list[LocationReport]]:
         """See `BaseAppleAccount.fetch_reports`."""
         date_to = date_to or datetime.now().astimezone()
 
@@ -671,7 +672,7 @@ class AsyncAppleAccount(BaseAppleAccount):
     @overload
     async def fetch_last_reports(
         self,
-        keys: KeyPair,
+        keys: HasHashedPublicKey,
         hours: int = 7 * 24,
     ) -> list[LocationReport]:
         ...
@@ -679,9 +680,9 @@ class AsyncAppleAccount(BaseAppleAccount):
     @overload
     async def fetch_last_reports(
         self,
-        keys: Sequence[KeyPair],
+        keys: Sequence[HasHashedPublicKey],
         hours: int = 7 * 24,
-    ) -> dict[KeyPair, list[LocationReport]]:
+    ) -> dict[HasHashedPublicKey, list[LocationReport]]:
         ...
 
     @overload
@@ -696,9 +697,9 @@ class AsyncAppleAccount(BaseAppleAccount):
     @override
     async def fetch_last_reports(
         self,
-        keys: KeyPair | Sequence[KeyPair] | RollingKeyPairSource,
+        keys: HasHashedPublicKey | Sequence[HasHashedPublicKey] | RollingKeyPairSource,
         hours: int = 7 * 24,
-    ) -> list[LocationReport] | dict[KeyPair, list[LocationReport]]:
+    ) -> list[LocationReport] | dict[HasHashedPublicKey, list[LocationReport]]:
         """See `BaseAppleAccount.fetch_last_reports`."""
         end = datetime.now(tz=timezone.utc)
         start = end - timedelta(hours=hours)
@@ -1033,7 +1034,7 @@ class AppleAccount(BaseAppleAccount):
     @overload
     def fetch_reports(
         self,
-        keys: KeyPair,
+        keys: HasHashedPublicKey,
         date_from: datetime,
         date_to: datetime | None,
     ) -> list[LocationReport]:
@@ -1042,10 +1043,10 @@ class AppleAccount(BaseAppleAccount):
     @overload
     def fetch_reports(
         self,
-        keys: Sequence[KeyPair],
+        keys: Sequence[HasHashedPublicKey],
         date_from: datetime,
         date_to: datetime | None,
-    ) -> dict[KeyPair, list[LocationReport]]:
+    ) -> dict[HasHashedPublicKey, list[LocationReport]]:
         ...
 
     @overload
@@ -1060,10 +1061,10 @@ class AppleAccount(BaseAppleAccount):
     @override
     def fetch_reports(
         self,
-        keys: KeyPair | Sequence[KeyPair] | RollingKeyPairSource,
+        keys: HasHashedPublicKey | Sequence[HasHashedPublicKey] | RollingKeyPairSource,
         date_from: datetime,
         date_to: datetime | None,
-    ) -> list[LocationReport] | dict[KeyPair, list[LocationReport]]:
+    ) -> list[LocationReport] | dict[HasHashedPublicKey, list[LocationReport]]:
         """See `AsyncAppleAccount.fetch_reports`."""
         coro = self._asyncacc.fetch_reports(keys, date_from, date_to)
         return self._evt_loop.run_until_complete(coro)
@@ -1071,7 +1072,7 @@ class AppleAccount(BaseAppleAccount):
     @overload
     def fetch_last_reports(
         self,
-        keys: KeyPair,
+        keys: HasHashedPublicKey,
         hours: int = 7 * 24,
     ) -> list[LocationReport]:
         ...
@@ -1079,9 +1080,9 @@ class AppleAccount(BaseAppleAccount):
     @overload
     def fetch_last_reports(
         self,
-        keys: Sequence[KeyPair],
+        keys: Sequence[HasHashedPublicKey],
         hours: int = 7 * 24,
-    ) -> dict[KeyPair, list[LocationReport]]:
+    ) -> dict[HasHashedPublicKey, list[LocationReport]]:
         ...
 
     @overload
@@ -1095,9 +1096,9 @@ class AppleAccount(BaseAppleAccount):
     @override
     def fetch_last_reports(
         self,
-        keys: KeyPair | Sequence[KeyPair] | RollingKeyPairSource,
+        keys: HasHashedPublicKey | Sequence[HasHashedPublicKey] | RollingKeyPairSource,
         hours: int = 7 * 24,
-    ) -> list[LocationReport] | dict[KeyPair, list[LocationReport]]:
+    ) -> list[LocationReport] | dict[HasHashedPublicKey, list[LocationReport]]:
         """See `AsyncAppleAccount.fetch_last_reports`."""
         coro = self._asyncacc.fetch_last_reports(keys, hours)
         return self._evt_loop.run_until_complete(coro)

--- a/findmy/reports/reports.py
+++ b/findmy/reports/reports.py
@@ -48,6 +48,16 @@ class LocationReport(HasHashedPublicKey):
         return self._hashed_adv_key
 
     @property
+    def key(self) -> KeyPair:
+        """`KeyPair` using which this report was decrypted."""
+        if not self.is_decrypted:
+            msg = "Full key is unavailable while the report is encrypted."
+            raise RuntimeError(msg)
+        assert self._decrypted_data is not None
+
+        return self._decrypted_data[0]
+
+    @property
     def payload(self) -> bytes:
         """Full (partially encrypted) payload of the report, as retrieved from Apple."""
         return self._payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ ignore = [
     "D212", # multi-line docstring start at first line
     "D105", # docstrings in magic methods
 
+    "S101",  # assert statements
+
     "PLR2004", # "magic" values >.>
     "FBT",     # boolean "traps"
 ]


### PR DESCRIPTION
Relaxes the report fetching constraint to any type that has a hashed public key, instead of requiring the full private key. This means that reports can now be in an "unencrypted" state, where some fields (lat / long, confidence, status byte) are unavailable.

When supplied with a regular `KeyPair`, reports are automatically decrypted. The public API is also largely unchanged, so this change should be backwards compatible.
