### PR TITLE
fix: Unawaited coroutine errors on `Closable`

### DIFF
--- a/findmy/util/closable.py
+++ b/findmy/util/closable.py
@@ -29,6 +29,9 @@ class Closable(ABC):
         """Attempt to automatically clean up when garbage collected."""
         try:
             loop = self._loop or asyncio.get_running_loop()
-            loop.call_soon_threadsafe(loop.create_task, self.close())
+            if loop.is_running():
+                loop.call_soon_threadsafe(loop.create_task, self.close())
+            else:
+                loop.run_until_complete(self.close())
         except RuntimeError:
             pass


### PR DESCRIPTION
Should fix `Coroutine <xxx> was never awaited` errors and warnings on exit.

Closes #59 