### PR TITLE
reset device_fut when timeout is reached

### DIFF
--- a/findmy/scanner/scanner.py
+++ b/findmy/scanner/scanner.py
@@ -393,7 +393,8 @@ class OfflineFindingScanner:
                     yield device
 
                 time_left = stop_at - time.time()
-        except (asyncio.CancelledError, asyncio.TimeoutError):  # timeout reached
+        except asyncio.TimeoutError:  # timeout reached
+            self._device_fut = self._loop.create_future()
             return
         finally:
             await self._stop_scan()


### PR DESCRIPTION
Previously there was a bug that the scanner can only run for the first scan, and the rest will be cancelled immediately