### PR TITLE
Fixed uv build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ ignore = [
 ]
 
 [tool.setuptools]
-py-modules = ["findmy"]
+packages = ["findmy"]
 
 [build-system]
 requires = ["setuptools", "setuptools-scm"]


### PR DESCRIPTION
`uv build` was producing an empty wheel when building from Git (only included the metadata and no code), meaning the package couldn't be used. Somehow, a regular pip install git+ worked... 

I've never seen `py-modules` used, but judging by the [docs](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#py-modules), it's not the completely correct solution here. `packages` is the usual way of whitelisting what to include and it seems to fix the issue.

Reproducible example:

```bash
$ uv init
Initialized project `tmp`

$ uv add git+https://github.com/malmeloo/FindMy.py
Resolved 61 packages in 2ms
Audited 28 packages in 0.20ms

$ uv run python -c 'import findmy; print(findmy)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import findmy; print(findmy)
    ^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'findmy'
```

After the fix:

```bash

$ uv init
Initialized project `tmp2`

$ uv add git+https://github.com/franga2000/FindMy.py
Resolved 61 packages in 131ms
Audited 28 packages in 0.12ms

$ uv run python -c 'import findmy; print(findmy)'
<module 'findmy' from '.venv/lib/python3.13/site-packages/findmy/__init__.py'>
```

*PS: Thanks for this amazing library! I'm working on a little 