### PR TITLE
feat: disable mandb trigger when installing packages in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,14 @@ jobs:
       - uses: "./.github/actions/setup-project"
 
       - name: Install graphviz
-        run: sudo apt-get install -y graphviz
+        run: |
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+          path-exclude /usr/share/doc/*
+          path-exclude /usr/share/man/*
+          path-exclude /usr/share/info/*
+          EOF
+          
+          sudo apt-get install -y graphviz
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
The mandb trigger is incredibly slow and we don't need it