### PR TITLE
fix: save cached keys to correct index

### DIFF
--- a/findmy/accessory.py
+++ b/findmy/accessory.py
@@ -396,7 +396,7 @@ class _AccessoryKeyGenerator(KeyGenerator[KeyPair]):
     # cache enough keys for an entire week.
     # every interval'th key is cached.
     _CACHE_SIZE = 4 * 24 * 7  # 4 keys / hour
-    _CACHE_INTERVAL = 10
+    _CACHE_INTERVAL = 1  # cache every key
 
     def __init__(
         self,
@@ -460,7 +460,7 @@ class _AccessoryKeyGenerator(KeyGenerator[KeyPair]):
                 cur_sk = self._sk_cache[cached_ind]
 
         # compute and update cache
-        for cur_ind in range(start_ind, ind):
+        for cur_ind in range(start_ind + 1, ind + 1):
             cur_sk = crypto.x963_kdf(cur_sk, b"update", 32)
 
             # insert intermediate result into cache and evict oldest entry if necessary


### PR DESCRIPTION
Off-by-1 error causing the caching logic to save keys to the incorrect index. Fetching locations for the same airtag could therefore fail if attempted multiple times in the same session.

Also updates caching interval to 1 so that every key is saved, trading slightly higher memory usage with better performance