### PR TITLE
Fix decryption on Ventura 13.6 for bare-metal M1 instances

### DIFF
--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -43,14 +43,12 @@ def _parse_beaconstore_key_from_output(output: str) -> bytes:
 def _get_beaconstore_key() -> bytes:
     try:
         # This thing will pop up 2 Password Input windows...
-        key_in_hex = subprocess.getoutput(
-            "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
-        )
+        key_in_hex = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore' -w") # noqa: S605
         if not key_in_hex:
-            raise ValueError("Empty output from security -w")
+            raise ValueError("Empty output from security -w")  # noqa: EM101, TRY003
         return bytes.fromhex(key_in_hex)
-    except Exception:
-        output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'")
+    except (ValueError, subprocess.SubprocessError):
+        output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'") # noqa: S605
         return _parse_beaconstore_key_from_output(output)
 
 

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -45,7 +45,7 @@ def _get_beaconstore_key() -> bytes:
         # This thing will pop up 2 Password Input windows...
         key_in_hex = subprocess.getoutput(
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
-        )  # noqa: S605
+        )
         if not key_in_hex:
             raise ValueError("Empty output from security -w")  # noqa: EM101, TRY003, TRY301
         return bytes.fromhex(key_in_hex)

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -43,7 +43,7 @@ def _parse_beaconstore_key_from_output(output: str) -> bytes:
 def _get_beaconstore_key() -> bytes:
     try:
         # This thing will pop up 2 Password Input windows...
-        key_in_hex = subprocess.getoutput( # noqa: S605
+        key_in_hex = subprocess.getoutput(  # noqa: S605
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
         )
         if not key_in_hex:

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -47,7 +47,7 @@ def _get_beaconstore_key() -> bytes:
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
         )  # noqa: S605
         if not key_in_hex:
-            raise ValueError("Empty output from security -w")  # noqa: EM101, TRY003
+            raise ValueError("Empty output from security -w")  # noqa: EM101, TRY003, TRY301
         return bytes.fromhex(key_in_hex)
     except (ValueError, subprocess.SubprocessError):
         output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'")  # noqa: S605

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -43,12 +43,14 @@ def _parse_beaconstore_key_from_output(output: str) -> bytes:
 def _get_beaconstore_key() -> bytes:
     try:
         # This thing will pop up 2 Password Input windows...
-        key_in_hex = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore' -w") # noqa: S605
+        key_in_hex = subprocess.getoutput(
+            "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
+        )  # noqa: S605
         if not key_in_hex:
             raise ValueError("Empty output from security -w")  # noqa: EM101, TRY003
         return bytes.fromhex(key_in_hex)
     except (ValueError, subprocess.SubprocessError):
-        output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'") # noqa: S605
+        output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'")  # noqa: S605
         return _parse_beaconstore_key_from_output(output)
 
 

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 import logging
 import plistlib
+import re
 import subprocess
 from pathlib import Path
 from typing import IO
-import re 
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 _DEFAULT_SEARCH_PATH = Path.home() / "Library" / "com.apple.icloud.searchpartyd"
 
 
-
 def _parse_beaconstore_key_from_output(output: str) -> bytes:
     if '"acct"<blob>="BeaconStoreKey"' not in output:
         raise ValueError
@@ -35,7 +34,8 @@ def _parse_beaconstore_key_from_output(output: str) -> bytes:
     if not m:
         raise ValueError
     return bytes.fromhex(m.group(1))
-    
+
+
 # consider switching to this library https://github.com/microsoft/keyper
 # once they publish a version of it that includes my MR with the changes to make it compatible
 # with keys that are non-utf-8 encoded (like the BeaconStore one)
@@ -45,15 +45,14 @@ def _get_beaconstore_key() -> bytes:
         # This thing will pop up 2 Password Input windows...
         key_in_hex = subprocess.getoutput(
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
-        )        
+        )
         if not key_in_hex:
             raise ValueError("Empty output from security -w")
         return bytes.fromhex(key_in_hex)
     except Exception:
-        output = subprocess.getoutput(
-            "/usr/bin/security find-generic-password -l 'BeaconStore'"
-        )
+        output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'")
         return _parse_beaconstore_key_from_output(output)
+
 
 def _get_accessory_name(
     accessory_id: str,

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -43,7 +43,7 @@ def _parse_beaconstore_key_from_output(output: str) -> bytes:
 def _get_beaconstore_key() -> bytes:
     try:
         # This thing will pop up 2 Password Input windows...
-        key_in_hex = subprocess.getoutput(
+        key_in_hex = subprocess.getoutput( # noqa: S605
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
         )
         if not key_in_hex:

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -27,13 +27,20 @@ logger = logging.getLogger(__name__)
 _DEFAULT_SEARCH_PATH = Path.home() / "Library" / "com.apple.icloud.searchpartyd"
 
 
-def _parse_beaconstore_key_from_output(output: str) -> bytes:
+def _parse_beaconstore_key_from_string_output(output: str) -> bytes:
     if '"acct"<blob>="BeaconStoreKey"' not in output:
         raise ValueError
     m = re.search(r'"gena"<blob>=0x([0-9A-Fa-f]+)', output)
     if not m:
         raise ValueError
     return bytes.fromhex(m.group(1))
+
+
+def _parse_beaconstore_key_from_hex_output(output: str) -> bytes:
+    if not output:
+        msg = "Empty output from security -w"
+        raise ValueError(msg)
+    return bytes.fromhex(output)
 
 
 # consider switching to this library https://github.com/microsoft/keyper
@@ -46,12 +53,10 @@ def _get_beaconstore_key() -> bytes:
         key_in_hex = subprocess.getoutput(  # noqa: S605
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
         )
-        if not key_in_hex:
-            raise ValueError("Empty output from security -w")
-        return bytes.fromhex(key_in_hex)
+        return _parse_beaconstore_key_from_hex_output(key_in_hex)
     except (ValueError, subprocess.SubprocessError):
         output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'")  # noqa: S605
-        return _parse_beaconstore_key_from_output(output)
+        return _parse_beaconstore_key_from_string_output(output)
 
 
 def _get_accessory_name(

--- a/findmy/plist.py
+++ b/findmy/plist.py
@@ -47,7 +47,7 @@ def _get_beaconstore_key() -> bytes:
             "/usr/bin/security find-generic-password -l 'BeaconStore' -w"
         )
         if not key_in_hex:
-            raise ValueError("Empty output from security -w")  # noqa: EM101, TRY003, TRY301
+            raise ValueError("Empty output from security -w")
         return bytes.fromhex(key_in_hex)
     except (ValueError, subprocess.SubprocessError):
         output = subprocess.getoutput("/usr/bin/security find-generic-password -l 'BeaconStore'")  # noqa: S605


### PR DESCRIPTION
While running Find My decryption on a bare-metal M1 instance (Ventura 13.6) on Scaleway, I encountered an issue: the AES key resolved as empty (key_in_hex: ''), causing decryption to fail. Surprisingly, no password prompt appeared, even though I was connected via VNC (not SSH).

This patch adjusts the authentication/decryption flow, which resolved the issue in my environment. Decryption now completes successfully on Ventura 13.6 on bare-metal M1 instances. 

It is only a fallback, so it shouldn't impact any other users.