### PR TITLE
increase account retrys to help with older airtags initial sync

### DIFF
--- a/findmy/reports/account.py
+++ b/findmy/reports/account.py
@@ -652,7 +652,7 @@ class AsyncAppleAccount(BaseAppleAccount):
             # Symptom: HTTP 200 but empty response
             # Remove when real issue fixed
             retry_counter = 1
-            _max_retries = 5
+            _max_retries = 20
             while True:
                 resp = await self._http.post(
                     self._ENDPOINT_REPORTS_FETCH,


### PR DESCRIPTION
Due to apple server errors, older airtags take long enough to the sync always fails with a 5 retry limit.

For airtags ~2yrs old, the highest retry needed was 16, and took over 20 minutes for the initial sync.