### PR TITLE
Add apple-find-my-sync to related projects

### DIFF
--- a/docs/related/index.md
+++ b/docs/related/index.md
@@ -103,6 +103,12 @@ _Author: [lanrat](https://github.com/lanrat)_
 
 Fork of findmy-traccar-bridge with some improvements.
 
+#### 🐍 [apple-find-my-sync](https://github.com/nikita-skakun/apple-find-my-sync)
+
+_Author: [nikita-skakun](https://github.com/nikita-skakun)_
+
+Service to sync Apple Find My device locations to Traccar.
+
 ## Libraries
 
 #### 🐍 [SwiftFindMy](https://github.com/airy10/SwiftFindMy)


### PR DESCRIPTION
apple-find-my-sync is a python microservice I made that syncs Apple Find My device locations to Traccar. It fits alongside existing Traccar integrations listed in the Related Projects section.