### PR TITLE
Fix rolling accessory location history fetching

### DIFF
--- a/findmy/reports/account.py
+++ b/findmy/reports/account.py
@@ -785,7 +785,7 @@ class AsyncAppleAccount(BaseAppleAccount):
         | None
     ):
         """See :meth:`BaseAppleAccount.fetch_location`."""
-        hist = await self.fetch_location_history(keys)
+        hist = await self._reports.fetch_location_history(keys, only_latest=True)
         if isinstance(hist, list):
             return sorted(hist)[-1] if hist else None
 
@@ -1188,11 +1188,8 @@ class AppleAccount(BaseAppleAccount):
         | None
     ):
         """See :meth:`BaseAppleAccount.fetch_location`."""
-        hist = self.fetch_location_history(keys)
-        if isinstance(hist, list):
-            return sorted(hist)[-1] if hist else None
-
-        return {dev: sorted(reports)[-1] if reports else None for dev, reports in hist.items()}
+        coro = self._asyncacc.fetch_location(keys)
+        return self._evt_loop.run_until_complete(coro)
 
     @override
     def get_anisette_headers(

--- a/findmy/reports/reports.py
+++ b/findmy/reports/reports.py
@@ -342,18 +342,24 @@ class LocationReportsFetcher:
     async def fetch_location_history(
         self,
         device: HasHashedPublicKey,
+        *,
+        only_latest: bool = False,
     ) -> list[LocationReport]: ...
 
     @overload
     async def fetch_location_history(
         self,
         device: RollingKeyPairSource,
+        *,
+        only_latest: bool = False,
     ) -> list[LocationReport]: ...
 
     @overload
     async def fetch_location_history(
         self,
         device: Sequence[HasHashedPublicKey | RollingKeyPairSource],
+        *,
+        only_latest: bool = False,
     ) -> dict[HasHashedPublicKey | RollingKeyPairSource, list[LocationReport]]: ...
 
     async def fetch_location_history(
@@ -361,6 +367,8 @@ class LocationReportsFetcher:
         device: HasHashedPublicKey
         | RollingKeyPairSource
         | Sequence[HasHashedPublicKey | RollingKeyPairSource],
+        *,
+        only_latest: bool = False,
     ) -> (
         list[LocationReport] | dict[HasHashedPublicKey | RollingKeyPairSource, list[LocationReport]]
     ):
@@ -386,7 +394,7 @@ class LocationReportsFetcher:
 
         if isinstance(device, RollingKeyPairSource):
             # key generator
-            return await self._fetch_accessory_reports(device, only_latest=True)
+            return await self._fetch_accessory_reports(device, only_latest=only_latest)
 
         if not isinstance(device, list) or not all(
             isinstance(x, HasHashedPublicKey | RollingKeyPairSource) for x in device
@@ -408,7 +416,7 @@ class LocationReportsFetcher:
                 static_keys.append(dev)
             elif isinstance(dev, RollingKeyPairSource):
                 # query immediately
-                reports[dev] = await self._fetch_accessory_reports(dev, only_latest=True)
+                reports[dev] = await self._fetch_accessory_reports(dev, only_latest=only_latest)
 
         if static_keys:  # batch request for static keys
             key_reports = await self._fetch_key_reports(static_keys)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,79 @@
+"""Location report fetcher tests."""
+
+import asyncio
+from datetime import datetime
+
+from typing_extensions import override
+
+from findmy import KeyPair
+from findmy.accessory import RollingKeyPairSource
+from findmy.reports.reports import LocationReport, LocationReportsFetcher
+
+
+class DummyAccessory(RollingKeyPairSource):
+    """Minimal rolling key source for dispatch tests."""
+
+    @override
+    def get_min_index(self, dt: datetime) -> int:
+        """Return a dummy minimum key index."""
+        _ = dt
+        return 0
+
+    @override
+    def get_max_index(self, dt: datetime) -> int:
+        """Return a dummy maximum key index."""
+        _ = dt
+        return 0
+
+    @override
+    def update_alignment(self, dt: datetime, index: int) -> None:
+        """Ignore alignment updates."""
+        _ = (dt, index)
+
+    @override
+    def keys_at(self, ind: int) -> set[KeyPair]:
+        """Return no keys."""
+        _ = ind
+        return set()
+
+
+class RecordingFetcher(LocationReportsFetcher):
+    """Fetcher that records only_latest values passed to accessory fetching."""
+
+    def __init__(self, accessory: RollingKeyPairSource) -> None:
+        """Initialize the recording fetcher."""
+        super().__init__(account=None)  # type: ignore[arg-type]
+        self.accessory = accessory
+        self.calls: list[bool] = []
+
+    @override
+    async def _fetch_accessory_reports(
+        self,
+        accessory: RollingKeyPairSource,
+        only_latest: bool = False,
+    ) -> list[LocationReport]:
+        assert accessory is self.accessory
+        self.calls.append(only_latest)
+        return []
+
+
+def test_fetch_location_history_fetches_full_rolling_history_by_default() -> None:
+    """Rolling-key history should not stop after the latest report."""
+    accessory = DummyAccessory()
+    fetcher = RecordingFetcher(accessory)
+
+    result = asyncio.run(fetcher.fetch_location_history(accessory))
+
+    assert result == []
+    assert fetcher.calls == [False]
+
+
+def test_fetch_location_history_can_fetch_latest_rolling_report() -> None:
+    """Internal latest-location callers can still stop after the latest report."""
+    accessory = DummyAccessory()
+    fetcher = RecordingFetcher(accessory)
+
+    result = asyncio.run(fetcher.fetch_location_history([accessory], only_latest=True))
+
+    assert result == {accessory: []}
+    assert fetcher.calls == [True]


### PR DESCRIPTION
## Summary

- make `fetch_location_history()` fetch the full rolling key history by default
- keep `fetch_location()` on the faster latest-only path explicitly
- add regression tests for default full-history behavior and the internal latest-only override

## Why

`LocationReportsFetcher.fetch_location_history()` accepted a `RollingKeyPairSource`, but internally always passed `only_latest=True` to `_fetch_accessory_reports()`. That meant callers asking for history could silently get only the newest report batch for rolling accessories.

This keeps the public history method aligned with its name while preserving current-location performance through `fetch_location()`.

## Tests

- `.venv/bin/python -m pytest tests/test_reports.py tests/test_keygen.py`
- `.venv/bin/python -m ruff check findmy/reports/account.py findmy/reports/reports.py tests/test_reports.py`
